### PR TITLE
Only do transforms on JS platform

### DIFF
--- a/kotlin-react-function-plugin/src/main/kotlin/com/bnorm/react/ReactFunctionIrGenerationExtension.kt
+++ b/kotlin-react-function-plugin/src/main/kotlin/com/bnorm/react/ReactFunctionIrGenerationExtension.kt
@@ -21,11 +21,14 @@ import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.js.messageCollectorLogger
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.platform.js.isJs
 
 class ReactFunctionIrGenerationExtension(private val messageCollector: MessageCollector) : IrGenerationExtension {
   override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
-    for (file in moduleFragment.files) {
-      ReactFunctionCallTransformer(pluginContext, messageCollector).runOnFileInOrder(file)
+    if(moduleFragment.descriptor.platform.isJs()) {
+      for (file in moduleFragment.files) {
+        ReactFunctionCallTransformer(pluginContext, messageCollector).runOnFileInOrder(file)
+      }
     }
   }
 }

--- a/kotlin-react-function-plugin/src/main/kotlin/com/bnorm/react/ReactFunctionIrGenerationExtension.kt
+++ b/kotlin-react-function-plugin/src/main/kotlin/com/bnorm/react/ReactFunctionIrGenerationExtension.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.platform.js.isJs
 
 class ReactFunctionIrGenerationExtension(private val messageCollector: MessageCollector) : IrGenerationExtension {
   override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
-    if(moduleFragment.descriptor.platform.isJs()) {
+    if (moduleFragment.descriptor.platform.isJs()) {
       for (file in moduleFragment.files) {
         ReactFunctionCallTransformer(pluginContext, messageCollector).runOnFileInOrder(file)
       }


### PR DESCRIPTION
Fixes #6.  Simply checks that the platform is JS before initalizing ReactFunctionCallTransformer.

`sample` has been tested and still works, it works on my multiplatform project as well.